### PR TITLE
lacrosse custom FF;

### DIFF
--- a/selfdrive/car/gm/interface.py
+++ b/selfdrive/car/gm/interface.py
@@ -36,12 +36,27 @@ class CarInterface(CarInterfaceBase):
     desired_angle *= 0.09760208
     sigmoid = desired_angle / (1 + fabs(desired_angle))
     return 0.04689655 * sigmoid * (v_ego + 10.028217)
+  
+  @staticmethod
+  def get_steer_feedforward_lacrosse(angle, speed):
+    ANGLE_COEF = 0.58539783
+    ANGLE_COEF2 = 0.32765082
+    ANGLE_OFFSET = 0.00460531
+    SPEED_OFFSET = 13.23075991
+    SIGMOID_COEF_RIGHT = 0.13719471
+    SIGMOID_COEF_LEFT = 0.13309956
+    SPEED_COEF = 0.06147823
+    x = ANGLE_COEF * (angle + ANGLE_OFFSET)
+    sigmoid = x / (1. + fabs(x))
+    return ((SIGMOID_COEF_RIGHT if (angle + ANGLE_OFFSET) > 0. else SIGMOID_COEF_LEFT) * sigmoid) * ((speed + SPEED_OFFSET) * SPEED_COEF) * ((fabs(angle + ANGLE_OFFSET) ** fabs(ANGLE_COEF2)))
 
   def get_steer_feedforward_function(self):
     if self.CP.carFingerprint == CAR.VOLT:
       return self.get_steer_feedforward_volt
     elif self.CP.carFingerprint == CAR.ACADIA:
       return self.get_steer_feedforward_acadia
+    elif self.CP.carFingerprint == CAR.BUICK_LACROSSE:
+      return self.get_steer_feedforward_lacrosse
     else:
       return CarInterfaceBase.get_steer_feedforward_default
 
@@ -191,6 +206,9 @@ class CarInterface(CarInterfaceBase):
       ret.wheelbase = 2.90
       ret.steerRatio = 15.8
       ret.centerToFront = ret.wheelbase * 0.4  # wild guess
+      ret.lateralTuning.pid.kf = 1.  # get_steer_feedforward_lacrosse()
+      ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0., 40.], [0., 40.]]
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.05, 0.2], [0.01, 0.005]]
       
     elif candidate == CAR.BUICK_REGAL:
       ret.mass = 3779. * CV.LB_TO_KG + STD_CARGO_KG  # (3849+3708)/2


### PR DESCRIPTION
fit info:
describe(steer_offsets) = DescribeResult(nobs=1649402, minmax=(-0.7127894163131714, 5.3997602462768555), mean=3.3090523060153645, variance=0.3130325564084465, skewness=-1.5986155151533736, kurtosis=8.18810418298873) Samples: 1357787
Regularizing...
Regularized samples: 1140
speed: DescribeResult(nobs=1140, minmax=(8.478170424241286, 35.837870224662446), mean=27.888804767013475, variance=34.16742353763829, skewness=-1.068587303119431, kurtosis=0.6193071765927134) angle: DescribeResult(nobs=1140, minmax=(-21.057768565637094, 28.516874490999708), mean=-0.4328602593886506, variance=43.19046813273241, skewness=0.001966426701503317, kurtosis=0.20547357649038434) steer: DescribeResult(nobs=1140, minmax=(-0.8432471203007578, 0.9634959333674695), mean=-0.021981142946747863, variance=0.20152217060233915, skewness=0.03202313890158864, kurtosis=-1.2318826088567174) Performing fit...
Fit: [5.85397825e-01 3.27650818e-01 4.60531117e-03 1.32307599e+01
 1.37194709e-01 1.33099557e-01 6.14782304e-02]
ANGLE_COEF = 0.58539783
ANGLE_COEF2 = 0.32765082
ANGLE_OFFSET = 0.00460531
SPEED_OFFSET = 13.23075991
SIGMOID_COEF_RIGHT = 0.13719471
SIGMOID_COEF_LEFT = 0.13309956
SPEED_COEF = 0.06147823
MAE old 0.2098, new 0.0309
STD old 0.1021, new 0.0273
deg 00-03:457, deg 03-06:258, deg 06-09:218, deg 09-12:132, deg 12-15:62 deg 15-18:6, deg 18-21:4, deg 21-24:1, deg 24-27:0, deg 27-30:2 deg 30-33:0, deg 33-36:0, deg 36-39:0, deg 39-42:0, deg 42-45:0

mph 10-15:0, mph 15-20:1, mph 20-25:18, mph 25-30:12, mph 30-35:30 mph 35-40:26, mph 40-45:52, mph 45-50:54, mph 50-55:73, mph 55-60:86 mph 60-65:204, mph 65-70:228, mph 70-75:179, mph 75-80:176, mph 80-85:1 mph 85-90:0,

https://opengraph.githubassets.com/5af6968b48c7f2da048c9a8f5b33482e336878e767e07a60a7e53168dbf0c582/twilsonco/openpilot/commit/da3656529ca8d82cf99dbfaa97c1c690273461ef

1649402 points filtered down to 1357787
mean absolute error: old 0.2098, new 0.0309
standard deviation: old 0.1021, new 0.0273
fit computed using 1140 points